### PR TITLE
Fix Simplex Regularization

### DIFF
--- a/examples/simple_glrms.jl
+++ b/examples/simple_glrms.jl
@@ -83,6 +83,22 @@ function fit_pca_nucnorm_sparse_nonuniform(m,n,k,s)
 	return A,X,Y,ch
 end
 
+function fit_simplex_pca(m,n,k)
+	# PCA with loadings constrained to lie on unit simplex
+	# constrain columns of X to lie on unit simplex
+	Xreal = rand(k,m)
+	Xreal ./= sum(Xreal,1)
+	A = Xreal' * randn(k,n)
+
+	loss = quadratic()
+	rx = simplex()
+	ry = zeroreg()
+	glrm = GLRM(A,loss,rx,ry,k)
+	X,Y,ch = fit!(glrm)	
+	println("Convergence history:",ch.objective)
+	return A,X,Y,ch
+end
+
 if true
 	srand(10)
 	fit_pca(100,100,2)

--- a/examples/simple_glrms.jl
+++ b/examples/simple_glrms.jl
@@ -83,7 +83,7 @@ function fit_pca_nucnorm_sparse_nonuniform(m,n,k,s)
 	return A,X,Y,ch
 end
 
-function fit_simplex_pca(m,n,k)
+function fit_soft_kmeans(m,n,k)
 	# PCA with loadings constrained to lie on unit simplex
 	# constrain columns of X to lie on unit simplex
 	Xreal = rand(k,m)

--- a/src/regularizers.jl
+++ b/src/regularizers.jl
@@ -157,7 +157,7 @@ end
 ## prox for the simplex is derived by Chen and Ye in [this paper](http://arxiv.org/pdf/1101.6081v2.pdf)
 type simplex<:Regularizer
 end
-function prox(r::simplex,u::AbstractArray,alpha::Number)
+function prox!(r::simplex,u::AbstractArray,alpha::Number)
     n = length(u)
     y = sort(u, rev=true)
     ysum = cumsum(y)
@@ -168,11 +168,13 @@ function prox(r::simplex,u::AbstractArray,alpha::Number)
             break
         end
     end
-    return max(u - t, 0)
+    for i = 1:n
+        u[i] = max(u[i] - t, 0)
+    end
 end
 function evaluate(r::simplex,a::AbstractArray)
     # check it's a unit vector
-    abs(sum(a)-1)>2*eps() && return Inf
+    abs(sum(a)-1)>1e-12 && return Inf
     # check every entry is nonnegative
     for i=1:length(a)
         a[i] < 0 && return Inf

--- a/src/regularizers.jl
+++ b/src/regularizers.jl
@@ -157,22 +157,22 @@ end
 ## prox for the simplex is derived by Chen and Ye in [this paper](http://arxiv.org/pdf/1101.6081v2.pdf)
 type simplex<:Regularizer
 end
-function prox!(r::simplex,u::AbstractArray,alpha::Number)
+function prox(r::simplex,u::AbstractArray,alpha::Number)
     n = length(u)
     y = sort(u, rev=true)
     ysum = cumsum(y)
-    t = ysum[end]/n
+    t = (ysum[end]-1)/n
     for i=1:n-1
         if (ysum[i] - 1)/i >= y[i+1]
             t = (ysum[i] - 1)/i
             break
         end
     end
-    u = max(u - t, 0)
+    return max(u - t, 0)
 end
 function evaluate(r::simplex,a::AbstractArray)
     # check it's a unit vector
-    sum(a)!=1 && return Inf
+    abs(sum(a)-1)>2*eps() && return Inf
     # check every entry is nonnegative
     for i=1:length(a)
         a[i] < 0 && return Inf


### PR DESCRIPTION
I've been trying to fix a couple of problems with the simplex regularizer that I ran into. Here is a brief summary:

* I added an example in `simple_glrms` for testing the simplex regularizer

* The prox operator was not returning the correct solution for vectors less than unit length: `prox(simplex(),[0.5, 0, 0],1.0)` would return `[0.3333 0.0 0.0]` for example. This is fixed by changing `t = ysum[end]/n` to `t = (ysum[end]-1)/n`.

* The `evaluate` function was returning `Inf` due to small floating point errors. So I changed `sum(a)==1` to `abs(sum(a)-1)>2*eps()`. I'm not sure if there is a more principled way of handling this?

Then there was a third problem, which I'm not satisfied that I solved correctly:

* The `prox!` function was not updating `ve[e]` (the columns of `X`). Somehow, deleting the `!` in the function fixes this. It seems like `::AbstractArray` type can't be modified within `prox!`. I tried switching `u` to be an `::Array` but then got an error because the solver couldn't find an appropriate method for a `ContiguousView`. 

I'm confused as to why this last fix works, but it appears to produce the appropriate behavior... I end up with an `X` in which the columns are nonnegative and sum to one.

**Edit:** I realized that the generic method on this line is probably why deleting the `!` fixes things... https://github.com/madeleineudell/LowRankModels.jl/blob/master/src/regularizers.jl#L28