### PR TITLE
Fix sparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Regularizers:
 * 1-sparse constraint `onesparse` (eg, for orthogonal NNMF)
 * unit 1-sparse constraint `unitonesparse` (eg, for k-means)
 * simplex constraint `simplex`
+* l1 regularization, combined with nonnegative constraint `nonneg_onereg`
 
 Each of these losses and regularizers can be scaled 
 (for example, to increase the importance of the loss relative to the regularizer) 
@@ -203,6 +204,29 @@ labels outside the gender binary, if they appear in the data set.)
 You can use the model to get some intuition for the data set. For example,
 try plotting the columns of `Y` with the labels; you might see
 that similar features are close to each other!
+
+# Fitting Sparse Matrices
+
+If you have a very large, sparse dataset, then you will probably want to
+encode your data into a
+[sparse matrix](http://julia-demo.readthedocs.org/en/latest/stdlib/sparse.html).
+By default, `LowRankModels` interprets the sparse entries of a sparse
+matrix as missing entries (i.e. `NA` values). There is no need to
+pass the indices of observed entries (`obs`) -- this is done
+automatically when `GLRM(A::SparseMatrixCSC,...)` is called.
+In addition, calling `fit!(glrm)` when `glrm.A` is a sparse matrix
+will use the sparse variant of the proximal gradient descent algorithm,
+`fit!(glrm, SparseProxGradParams(); kwargs...)`.
+
+If, instead, you'd like to interpret the sparse entries as zeros, rather
+than missing or `NA` entries, use:
+```julia
+glrm = GLRM(...;sparse_na=false)
+```
+In this case, the dataset is dense in terms of observations, but sparse
+in terms of nonzero values. Thus, it may make more sense to fit the
+model with the vanilla proximal gradient descent algorithm,
+`fit!(glrm, ProxGradParams(); kwargs...)`.
 
 # Technical details
 

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -10,7 +10,13 @@ Params(args...; kwargs...) = ProxGradParams(args...; kwargs...)
     if :params in keys(kwdict)
         return fit!(glrm, kwdict[:params]; kwargs...)
     else
-        return fit!(glrm, ProxGradParams(); kwargs...)
+        if isa(A,SparseMatrixCSC)
+            # Default to sparse algorithm for a sparse dataset
+            return fit!(glrm, SparseProxGradParams(); kwargs...)
+        else
+            # Classic proximal gradient method for non-sparse data
+            return fit!(glrm, ProxGradParams(); kwargs...)
+        end
     end
 end
 

--- a/src/glrm.jl
+++ b/src/glrm.jl
@@ -41,6 +41,12 @@ function GLRM(A::AbstractArray, losses::Array, rx::Regularizer, ry::Array, k::In
     if length(ry)!=n error("There must be either one Y regularizer or as many Y regularizers as there are columns in the data matrix") end
     if size(X)!=(k,m) error("X must be of size (k,m) where m is the number of rows in the data matrix. This is the transpose of the standard notation used in the paper, but it makes for better memory management. size(X) = $(size(X)), size(A) = $(size(A))") end
     if size(Y)!=(k,n) error("Y must be of size (k,n) where n is the number of columns in the data matrix. size(Y) = $(size(Y)), size(A) = $(size(A))") end
+    
+    # Determine observed entries of data
+    if isa(A,SparseMatrixCSC)
+        I,J = findn(A) # observed indices (vectors)
+        obs = [(I[a],J[a]) for a = 1:length(I)] # observed indices (list of tuples)
+    end
     if obs==nothing # if no specified array of tuples, use what was explicitly passed in or the defaults (all)
         # println("no obs given, using observed_features and observed_examples")
         glrm = GLRM(A,losses,rx,ry,k, observed_features, observed_examples, X,Y)

--- a/src/glrm.jl
+++ b/src/glrm.jl
@@ -34,7 +34,7 @@ function GLRM(A::AbstractArray, losses::Array, rx::Regularizer, ry::Array, k::In
               observed_features = fill(1:size(A,2), size(A,1)), # [1:n, 1:n, ... 1:n] m times
               observed_examples = fill(1:size(A,1), size(A,2)), # [1:m, 1:m, ... 1:m] n times
               offset = false, scale = false,
-              checknan = true)
+              checknan = true, sparse_na = true)
     # Check dimensions of the arguments
     m,n = size(A)
     if length(losses)!=n error("There must be as many losses as there are columns in the data matrix") end
@@ -43,7 +43,7 @@ function GLRM(A::AbstractArray, losses::Array, rx::Regularizer, ry::Array, k::In
     if size(Y)!=(k,n) error("Y must be of size (k,n) where n is the number of columns in the data matrix. size(Y) = $(size(Y)), size(A) = $(size(A))") end
     
     # Determine observed entries of data
-    if isa(A,SparseMatrixCSC)
+    if obs==nothing && sparse_na && isa(A,SparseMatrixCSC)
         I,J = findn(A) # observed indices (vectors)
         obs = [(I[a],J[a]) for a = 1:length(I)] # observed indices (list of tuples)
     end

--- a/test/sparse_test.jl
+++ b/test/sparse_test.jl
@@ -1,20 +1,47 @@
 using Base.Test
 using LowRankModels
 
-# simple synthetic dataset for PCA
+# Check that sparse algorithm converges to the same solution
+# from the same initial conditions for simple pca.
 m,n,k = 100,100,3
 A = randn(m,k)*randn(k,n)
 loss = quadratic()
 r = zeroreg()
 
-
-# Check that sparse algorithm converges to the same solution
-# from the same initial conditions.
-glrm_1 = GLRM(A,loss,r,r,k)
-glrm_2 = deepcopy(glrm_1)
+glrm_1 = GLRM(A,loss,r,r,k) # solve with prox algorithm
+glrm_2 = deepcopy(glrm_1)   # solve with sparse prox algorithm
 
 X1,Y1,ch1 = fit!(glrm_1,ProxGradParams())
 X2,Y2,ch2 = fit!(glrm_2,SparseProxGradParams())
 
 @test_approx_eq X1 X2
 @test_approx_eq Y1 Y2
+
+# Check that the sparsity pattern in the data is correctly identified.
+A = sprand(m,n,0.5)
+I,J = findn(A)
+
+glrm = GLRM(A,loss,r,r,k) # create glrm from sparse matrix
+
+@test length(glrm.observed_features) == m
+@test length(glrm.observed_examples) == n
+
+for i = 1:m
+	for j = 1:n
+		if j in glrm.observed_features[i]
+			@test A[i,j] != 0.0
+		else
+			@test A[i,j] == 0.0
+		end
+	end
+end
+
+for j = 1:n
+	for i = 1:m
+		if i in glrm.observed_examples[j]
+			@test A[i,j] != 0.0
+		else
+			@test A[i,j] == 0.0
+		end
+	end
+end


### PR DESCRIPTION
At the moment, a sparse matrix is interpreted as being fully observed unless `obs` is passed a parameter to `GLRM`. This PR creates a boolean flag `sparse_na`, which signals that the sparse entries should be interpreted as `NA` and not as `0.0`. When `sparse_na == true` then `obs` is automatically calculated as follows:

```julia
if obs==nothing && sparse_na && isa(A,SparseMatrixCSC)
    I,J = findn(A) # observed indices (vectors)
    obs = [(I[a],J[a]) for a = 1:length(I)] # observed indices (list of tuples)
end
```

Does this make sense? Happy to revise or remove.