### PR TITLE
ScikitLearn.jl wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,44 @@ These functions should help you choose adequate regularization for your model.
 
 * `get_train_and_test(obs, m, n, holdout_proportion=.1)`: splits observations `obs` into a train and test set. `m` and `n` must be at least as large as the maximal value of the first or second elements of the tuples in `observations`, respectively. Returns `observed_features` and `observed_examples` for both train and test sets.
 
+## ScikitLearn
+
+This library implements the
+[ScikitLearn.jl](https://github.com/cstjean/ScikitLearn.jl) interface. These
+models are available: `SkGLRM, PCA, QPCA, NNMF, KMeans, RPCA`. See their
+docstrings for more information (eg. `?QPCA`). All models support the
+`ScikitLearnBase.fit!` and `ScikitLearnBase.transform` interface. Examples:
+
+```julia
+## Apply PCA to the iris dataset
+using LowRankModels
+import ScikitLearnBase
+using RDatasets    # may require Pkg.add("RDatasets")
+
+A = convert(Matrix, dataset("datasets", "iris")[[:SepalLength, :SepalWidth, :PetalLength, :PetalWidth]])
+ScikitLearnBase.fit_transform!(PCA(k=3, max_iter=500), A)
+```
+
+```julia
+## Fit K-Means to a fake dataset of two Gaussians
+using LowRankModels
+import ScikitLearnBase
+
+# Generate two disjoint Gaussians with 100 and 50 points
+gaussian1 = randn(100, 2) + 5
+gaussian2 = randn(50, 2) - 10
+# Merge them into a single dataset
+A = vcat(gaussian1, gaussian2)
+
+model = ScikitLearnBase.fit!(LowRankModels.KMeans(), A)
+# Count how many points are assigned to each Gaussians (should be 100 and 50)
+Set(sum(ScikitLearnBase.transform(model, A), 1))
+```
+
+See also [this notebook demonstrating K-Means](https://github.com/cstjean/ScikitLearn.jl/blob/master/examples/Plot_Kmeans_Digits_Julia.ipynb).
+
+These models can be used inside a [ScikitLearn pipeline](http://scikitlearnjl.readthedocs.io/en/latest/pipelines/), and every hyperparameter can be [tuned with GridSearchCV](http://scikitlearnjl.readthedocs.io/en/latest/model_selection/).
+
 # Citing this package
 
 If you use LowRankModels for published work, 

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ Optim
 Roots
 NMF
 Compat
+ScikitLearnBase 0.0.4

--- a/examples/cross_validate.jl
+++ b/examples/cross_validate.jl
@@ -29,10 +29,10 @@ end
 if do_reg_path
     println("Computing regularization path")
     params = Params(1.0, max_iter=50, abs_tol=.00001, min_stepsize=.01)
-    train_error, test_error, train_time, model_onenorm, reg_params = 
+    train_error, test_error, train_time, reg_params = 
     regularization_path(glrm, params=params, reg_params=logspace(2,-2,15))
     df = DataFrame(train_error = train_error, test_error = test_error,
-                   train_time = train_time, model_onenorm=model_onenorm, reg_param = reg_params)
+                   train_time = train_time, reg_param = reg_params)
 	if do_plot 
 		p = plot(df, :reg_param, [:train_error, :test_error]; scale = :log, filename = None)
 	end

--- a/examples/simple_glrms.jl
+++ b/examples/simple_glrms.jl
@@ -15,7 +15,7 @@ function fit_pca(m,n,k)
 	return A,X,Y,ch
 end
 
-# minimize_{X<=0, Y>=0} ||A - XY||^2
+# minimize_{X>=0, Y>=0} ||A - XY||^2
 function fit_nnmf(m,n,k)
 	# matrix to encode
 	A = rand(m,k)*rand(k,n)

--- a/src/LowRankModels.jl
+++ b/src/LowRankModels.jl
@@ -41,4 +41,7 @@ include("fit_dataframe.jl")
 include("utilities/conveniencemethods.jl")
 include("utilities/deprecated.jl")
 
+# ScikitLearn.jl compatibility
+include("scikitlearn.jl")
+
 end # module

--- a/src/algorithms/parallel_proxgrad.jl
+++ b/src/algorithms/parallel_proxgrad.jl
@@ -90,7 +90,7 @@ function fit!(glrm::ShareGLRM, params::ProxGradParams;
 
     # alternating updates of X and Y
     if verbose println("fitting GLRM") end
-    update!(ch, 0, objective(glrm,X,Y))
+    update_ch!(ch, 0, objective(glrm,X,Y))
     t = time()
     steps_in_a_row = 0
 
@@ -164,7 +164,7 @@ function fit!(glrm::ShareGLRM, params::ProxGradParams;
         totalobj = sum(obj)
         if totalobj < ch.objective[end]
             t = time() - t
-            update!(ch, t, totalobj)
+            update_ch!(ch, t, totalobj)
             #copy!(glrm.X, X); copy!(glrm.Y, Y)
             @everywhere begin
                 @inbounds for i in localindexes(X)
@@ -204,7 +204,7 @@ function fit!(glrm::ShareGLRM, params::ProxGradParams;
         end
     end
     t = time() - t
-    update!(ch, t, ch.objective[end])
+    update_ch!(ch, t, ch.objective[end])
 
     return glrm.X', glrm.Y, ch
 end

--- a/src/algorithms/proxgrad.jl
+++ b/src/algorithms/proxgrad.jl
@@ -67,7 +67,7 @@ function fit!(glrm::GLRM, params::ProxGradParams;
 
     # alternating updates of X and Y
     if verbose println("Fitting GLRM") end
-    update!(ch, 0, objective(glrm, X, Y, XY, yidxs=yidxs))
+    update_ch!(ch, 0, objective(glrm, X, Y, XY, yidxs=yidxs))
     t = time()
     steps_in_a_row = 0
     # gradient wrt columns of X
@@ -199,7 +199,7 @@ function fit!(glrm::GLRM, params::ProxGradParams;
 # STEP 3: Record objective
         obj = sum(obj_by_col)
         t = time() - t
-        update!(ch, t, obj)
+        update_ch!(ch, t, obj)
         t = time()
 # STEP 4: Check stopping criterion
         obj_decrease = ch.objective[end-1] - obj

--- a/src/algorithms/sparse_proxgrad.jl
+++ b/src/algorithms/sparse_proxgrad.jl
@@ -47,7 +47,7 @@ function fit!(glrm::GLRM, params::SparseProxGradParams;
 
     # alternating updates of X and Y
     if verbose println("Fitting GLRM") end
-    update!(ch, 0, objective(glrm; sparse=true))
+    update_ch!(ch, 0, objective(glrm; sparse=true))
     t = time()
     steps_in_a_row = 0
     g = zeros(k)
@@ -103,7 +103,7 @@ function fit!(glrm::GLRM, params::SparseProxGradParams;
         # record the best X and Y yet found
         if obj < ch.objective[end]
             t = time() - t
-            update!(ch, t, obj)
+            update_ch!(ch, t, obj)
             copy!(glrm.X, X); copy!(glrm.Y, Y) # save new best X and Y
             alpha = alpha * 1.05
             steps_in_a_row = max(1, steps_in_a_row+1)
@@ -124,7 +124,7 @@ function fit!(glrm::GLRM, params::SparseProxGradParams;
         end
     end
     t = time() - t
-    update!(ch, t, ch.objective[end])
+    update_ch!(ch, t, ch.objective[end])
 
     return glrm.X, glrm.Y, ch
 end

--- a/src/convergence.jl
+++ b/src/convergence.jl
@@ -3,17 +3,31 @@ export ConvergenceHistory, update!
 type ConvergenceHistory
     name::AbstractString
     objective::Array
+    dual_objective::Array
     primal_residual::Array
     dual_residual::Array
     times::Array
     stepsizes::Array
     optval
 end
-ConvergenceHistory(name::AbstractString,optval=0) = ConvergenceHistory(name,Float64[],Float64[],Float64[],Float64[],Float64[],optval)
+ConvergenceHistory(name::AbstractString,optval=0) = ConvergenceHistory(name,Float64[],Float64[],Float64[],Float64[],Float64[],Float64[],optval)
 
-function update!(ch::ConvergenceHistory, dt, 
+function update_ch!(ch::ConvergenceHistory, dt, 
                  obj=0, stepsize=0, pr=0, dr=0)
     push!(ch.objective,obj)
+    push!(ch.primal_residual,pr)
+    push!(ch.dual_residual,dr)
+    push!(ch.stepsizes,stepsize)
+    if isempty(ch.times)
+        push!(ch.times,dt)
+    else
+        push!(ch.times,ch.times[end]+dt)
+    end
+end
+
+function update_ch!(ch::ConvergenceHistory, dt; obj=0, dual_obj=0, stepsize=0, pr=0, dr=0)
+    push!(ch.objective,obj)
+    push!(ch.dual_objective,dual_obj)
     push!(ch.primal_residual,pr)
     push!(ch.dual_residual,dr)
     push!(ch.stepsizes,stepsize)

--- a/src/evaluate_fit.jl
+++ b/src/evaluate_fit.jl
@@ -1,7 +1,7 @@
 export objective, error_metric, impute
 
 ### OBJECTIVE FUNCTION EVALUATION FOR MPCA
-function objective(glrm::AbstractGLRM, X::Array{Float64,2}, Y::Array{Float64,2}, 
+function objective(glrm::GLRM, X::Array{Float64,2}, Y::Array{Float64,2}, 
                    XY::Array{Float64,2}; 
                    yidxs = get_yidxs(glrm.losses), # mapping from columns of A to columns of Y; by default, the identity
                    include_regularization=true)
@@ -53,7 +53,7 @@ function col_objective(glrm::AbstractGLRM, j::Int, y::AbstractArray, X::Array{Fl
     return err
 end
 # The user can also pass in X and Y and `objective` will compute XY for them
-function objective(glrm::AbstractGLRM, X::Array{Float64,2}, Y::Array{Float64,2};
+function objective(glrm::GLRM, X::Array{Float64,2}, Y::Array{Float64,2};
                    sparse=false, include_regularization=true, 
                    yidxs = get_yidxs(glrm.losses), kwargs...)
     @assert(size(Y)==(glrm.k,yidxs[end][end]))
@@ -79,7 +79,7 @@ function objective(glrm::AbstractGLRM, X::Array{Float64,2}, Y::Array{Float64,2};
     end
 end
 # Or just the GLRM and `objective` will use glrm.X and .Y
-objective(glrm::AbstractGLRM; kwargs...) = objective(glrm, glrm.X, glrm.Y; kwargs...)
+objective(glrm::GLRM; kwargs...) = objective(glrm, glrm.X, glrm.Y; kwargs...)
 
 # For shared arrays
 # TODO: compute objective in parallel

--- a/src/glrm.jl
+++ b/src/glrm.jl
@@ -5,7 +5,7 @@ import ArrayViews: view, StridedView, ContiguousView
 
 abstract AbstractGLRM
 
-export AbstractGLRM, GLRM, getindex, size
+export AbstractGLRM, GLRM, getindex, size, scale_regularizer!
 
 typealias ObsArray @compat(Union{Array{Array{Int,1},1}, Array{UnitRange{Int},1}})
 
@@ -84,3 +84,10 @@ function GLRM(A, losses::Array, rx::Regularizer, ry::Array, k::Int;
 end
 
 parameter_estimate(glrm::GLRM) = (glrm.X, glrm.Y)
+
+
+function scale_regularizer!(glrm::GLRM, newscale::Number)
+    scale!(glrm.rx, newscale)
+    scale!(glrm.ry, newscale)
+    return glrm  
+end

--- a/src/losses.jl
+++ b/src/losses.jl
@@ -175,12 +175,14 @@ end
 
 ########################################## POISSON ##########################################
 # f: ℜxℕ -> ℜ
-# BEWARE: THIS LOSS MAY CAUSE MODEL INSTABLITY AND DIFFICULTY FITTING.
+# BEWARE: 
+# 1) this is a reparametrized poisson: we parametrize the mean as exp(u) so that u can take any real value and still produce a positive mean
+# 2) THIS LOSS MAY CAUSE MODEL INSTABLITY AND DIFFICULTY FITTING.
 type PoissonLoss<:Loss
     scale::Float64
     domain::Domain
 end
-PoissonLoss(max_count::Int, scale=1.0::Float64; domain=CountDomain(max_count)) = PoissonLoss(scale, domain)
+PoissonLoss(max_count::Int, scale=1.0::Float64; domain=CountDomain(max_count)::Domain) = PoissonLoss(scale, domain)
 
 function evaluate(l::PoissonLoss, u::Float64, a::Number) 
     l.scale*(exp(u) - a*u) # in reality this should be: e^u - a*u + a*log(a) - a, but a*log(a) - a is constant wrt a!

--- a/src/scikitlearn.jl
+++ b/src/scikitlearn.jl
@@ -1,0 +1,254 @@
+import ScikitLearnBase
+using ScikitLearnBase: declare_hyperparameters
+
+export SkGLRM, PCA, QPCA, NNMF, KMeans, RPCA
+
+################################################################################
+# Shared definitions
+
+# Note: there is redundancy in the hyperparameters. This is
+# necessary if we want to offer a simple interface in PCA(), and a full
+# interface in SkGLRM(). PCA(abs_tol=0.1, max_iter=200) cannot create 
+# `ProxGradParams(abs_tol, max_iter)` right away, because abs_tol and
+# max_iter are hyperparameters and need to be visible/changeable by
+# set_params for grid-search.
+# There are other ways of setting it up, but this seems like the simplest.
+type SkGLRM <: ScikitLearnBase.BaseEstimator
+    # Hyperparameters: those will be passed to GLRM, so it doesn't matter if
+    # they're not typed.
+    fit_params # if fit_params != nothing, it has priority over abs_tol, etc. 
+    loss
+    rx
+    ry
+    # rx/ry_scale can be nothing, in which case they're ignored. This allows
+    # ry to be a vector
+    rx_scale
+    ry_scale
+    abs_tol::Float64
+    rel_tol::Float64
+    max_iter::Int
+    inner_iter::Int
+    k::Int
+    init::Function   # initialization function
+    verbose::Bool
+
+    glrm::GLRM     # left undefined by the constructor
+end
+
+# This defines `clone`, `get_params` and `set_params!`
+declare_hyperparameters(SkGLRM, [:fit_params, :init, :rx, :ry,
+                                 :rx_scale, :ry_scale, :loss,
+                                 :abs_tol, :rel_tol, :max_iter, :inner_iter, :k,
+                                 :verbose])
+
+function do_fit!(skglrm::SkGLRM, glrm::GLRM)
+    fit_params = (skglrm.fit_params === nothing ?
+                  ProxGradParams(abs_tol=skglrm.abs_tol,
+                                 rel_tol=skglrm.rel_tol,
+                                 max_iter=skglrm.max_iter) :
+                  skglrm.fit_params)
+                  
+    fit!(glrm, fit_params; verbose=skglrm.verbose)
+end
+
+function build_glrm(skglrm::SkGLRM, X, missing_values::Matrix)
+    k = skglrm.k == -1 ? size(X, 2) : skglrm.k
+    obs = [ind2sub(missing_values, x) for x in find(!missing_values)]
+    rx, ry = skglrm.rx, skglrm.ry
+    if skglrm.rx_scale !== nothing
+        rx = copy(rx)
+        scale!(rx, skglrm.rx_scale)
+    end
+    if skglrm.ry_scale !== nothing
+        ry = copy(ry)
+        scale!(ry, skglrm.ry_scale)
+    end
+    GLRM(X, skglrm.loss, rx, ry, k; obs=obs)
+end
+
+# The input matrix is called X (instead of A) following ScikitLearn's convention
+function ScikitLearnBase.fit_transform!(skglrm::SkGLRM, X, y=nothing;
+                                        missing_values::Matrix=isnan(X))
+    @assert size(X)==size(missing_values)
+    
+    # Reuse the standard GLRM constructor and fitting machinery
+    skglrm.glrm = build_glrm(skglrm, X, missing_values)
+    skglrm.init(skglrm.glrm)
+    X, _, _ = do_fit!(skglrm, skglrm.glrm)
+    
+    return X'
+end
+
+function ScikitLearnBase.fit!(skglrm::SkGLRM, X, y=nothing; kwargs...)
+    ScikitLearnBase.fit_transform!(skglrm, X; kwargs...)
+    skglrm
+end
+
+
+""" `transform(skglrm::SkGLRM, X)` brings X to low-rank-space """
+function ScikitLearnBase.transform(skglrm::SkGLRM, X;
+                                   missing_values::Matrix=isnan(X))
+    glrm = skglrm.glrm
+    ry_fixed = [FixedLatentFeaturesConstraint(glrm.Y[:, i])
+                for i=1:size(glrm.Y, 2)]
+    glrm_fixed = build_glrm(skglrm, X, missing_values)
+    X2, _, ch = do_fit!(skglrm, glrm_fixed)
+    return X2'
+end
+
+
+""" `transform(skglrm::SkGLRM, X)` brings X from low-rank-space back to the
+original input-space """
+ScikitLearnBase.inverse_transform(skglrm::SkGLRM, X) = X * skglrm.glrm.Y
+
+# Only makes sense for KMeans
+function ScikitLearnBase.predict(km::SkGLRM, X)
+    X2 = ScikitLearnBase.transform(km, X)
+    # This performs the "argmax" over the columns to get the cluster #
+    return mapslices(indmax, X2, 2)[:]
+end
+
+################################################################################
+# Public constructors
+
+"""
+    SkGLRM(; fit_params=nothing, init=glrm->nothing, k::Int=-1, 
+           loss=QuadLoss(), rx::Regularizer=ZeroReg(), ry=ZeroReg(),
+           rx_scale=nothing, ry_scale=nothing,
+           # defaults taken from proxgrad.jl
+           abs_tol=0.00001, rel_tol=0.0001, max_iter=100, inner_iter=1,
+           verbose=false)
+
+Generalized low rank model (GLRM). GLRMs model a data array by a low rank
+matrix. GLRM makes it easy to mix and match loss functions and regularizers to
+construct a model suitable for a particular data set.
+
+Hyperparameters:
+
+- `fit_params`: algorithm to use in fitting the GLRM. Defaults to
+   `ProxGradParams(abs_tol, rel_tol, skglrm.max_iter)`
+- `init`: function to initialize the low-rank matrices, before the main gradient
+   descent loop.
+- `k`: number of components (rank of the latent representation). By default,
+   use k=nfeatures (full rank)
+- `loss`: loss function. Can be either a single `::Loss` object, or a vector
+   of `nfeature` loss objects, allowing for mixed inputs (eg. binary and
+   continuous data)
+- `rx`: regularization over the hidden coefficient matrix
+- `ry`: regularization over the latent features matrix. Can be either a single
+   regularizer, or a vector of regularizers of length nfeatures, allowing
+   for mixed inputs
+- `rx_scale`, `ry_scale`: strength of the regularization (higher is stronger).
+   By default, `scale=1`. Cannot be used if `rx/ry` are vectors.
+- `abs_tol, rel_tol`: tolerance criteria to stop the gradient descent iteration
+- `max_iter, inner_iter`: number of iterations in the gradient descent loops
+- `verbose`: print convergence information
+
+All parameters (in particular, `rx/ry_scale`) can be tuned with
+`ScikitLearn.GridSearch.GridSearchCV`
+
+For more information on the parameters see [LowRankModels](https://github.com/madeleineudell/LowRankModels.jl)
+"""
+function SkGLRM(; fit_params=nothing, init=glrm->nothing, k=-1, 
+                loss=QuadLoss(), rx=ZeroReg(), ry=ZeroReg(),
+                rx_scale=nothing, ry_scale=nothing,
+                # defaults taken from proxgrad.jl
+                abs_tol=0.00001, rel_tol=0.0001, max_iter=100, inner_iter=1,
+                verbose=false)
+    dummy = pca(zeros(1,1), 1) # it needs an initial value - will be overwritten
+    return SkGLRM(fit_params, loss, rx, ry, rx_scale, ry_scale, abs_tol,
+                  rel_tol, max_iter,
+                  inner_iter, k, init, verbose, dummy)
+end
+
+
+"""    PCA(; k=-1, ...)
+
+Principal Component Analysis with `k` components (defaults to using
+`nfeatures`). Equivalent to
+
+    SkGLRM(loss=QuadLoss(), rx=ZeroReg(), ry=ZeroReg(), init=init_svd!)
+
+See ?SkGLRM for more hyperparameters. In particular, increasing `max_iter`
+(default 100) may improve convergence. """
+function PCA(; kwargs...)
+    # principal components analysis
+    # minimize ||A - XY||^2
+    loss = QuadLoss()
+    r = ZeroReg()
+    return SkGLRM(; loss=loss, rx=r, ry=r, init=init_svd!, kwargs...)
+end
+
+
+"""    QPCA(k=-1, rx_scale=1, ry_scale=1; ...)
+
+Quadratically Regularized PCA with `k` components
+(default: `k = nfeatures`). Equivalent to
+
+    SkGLRM(loss=QuadLoss(), rx=QuadReg(1.0), ry=QuadReg(1.0), init=init_svd!)
+
+Regularization strength is set by `rx_scale` and `ry_scale`. See ?SkGLRM for
+more hyperparameters.
+"""
+function QPCA(; kwargs...)
+    # quadratically regularized principal components analysis
+    # minimize ||A - XY||^2 + rx_scale*||X||^2 + ry_scale*||Y||^2
+    loss = QuadLoss()
+    r = QuadReg(1.0) # scale is set in build_glrm
+    return SkGLRM(; loss=loss, rx=r, ry=r, init=init_svd!, kwargs...)
+end
+
+
+"""    NNMF(; k=-1, ...)
+
+Non-negative matrix factorization with `k` components (default:
+`k=nfeatures`). Equivalent to
+
+    SkGLRM(loss=QuadLoss(), rx=NonNegConstraint(), ry=NonNegConstraint(), init=init_svd!)
+
+See ?SkGLRM for more hyperparameters
+"""
+function NNMF(; kwargs...)
+    # nonnegative matrix factorization
+    # minimize_{X>=0, Y>=0} ||A - XY||^2
+    loss = QuadLoss()
+    r = NonNegConstraint()
+    return SkGLRM(; loss=loss,rx=r,ry=r, init=init_svd!, kwargs...)
+end
+
+
+"""    KMeans(; k=2, inner_iter=10, max_iter=100, ...)
+
+K-Means algorithm. Separates the data into `k` clusters. See ?SkGLRM for more
+hyperparameters. In particular, increasing `inner_iter` and `max_iter` may
+improve convergence.
+
+**IMPORTANT**: This is not the most efficient way of performing K-Means, and
+the iteration may not reach convergence.
+"""
+function KMeans(; k=2, inner_iter=10, kwargs...)
+    # minimize_{columns of X are unit vectors} ||A - XY||^2
+    loss = QuadLoss()
+    rx = UnitOneSparseConstraint() 
+    ry = ZeroReg()
+    return SkGLRM(k=k, loss=loss,rx=rx,ry=ry, inner_iter=inner_iter,
+                  init=init_kmeanspp!; kwargs...)
+end
+
+
+"""    RPCA(; k=-1, ...)
+
+Robust PCA with `k` components (default: `k = nfeatures`). Equivalent to
+
+    SkGLRM(loss=HuberLoss(), rx=QuadReg(1.0), ry=QuadReg(1.0), init=init_svd!)
+
+Regularization strength is set by `rx_scale` and `ry_scale`. See ?SkGLRM for
+more hyperparameters. In particular, increasing `max_iter` (default 100) may
+improve convergence. """
+function RPCA(; kwargs...)
+    # robust PCA
+    # minimize HuberLoss(A - XY) + scale*||X||^2 + scale*||Y||^2
+    loss = HuberLoss()
+    r = QuadReg(1.0)
+    return SkGLRM(; loss=loss,rx=r,ry=r, init=init_svd!, kwargs...)
+end

--- a/src/simple_glrms.jl
+++ b/src/simple_glrms.jl
@@ -17,7 +17,7 @@ function qpca(A::AbstractArray, k::Int; scale=1.0::Float64, kwargs...)
 end
 
 # nonnegative matrix factorization
-# minimize_{X<=0, Y>=0} ||A - XY||^2
+# minimize_{X>=0, Y>=0} ||A - XY||^2
 function nnmf(A::AbstractArray, k::Int; kwargs...)
 	loss = QuadLoss()
 	r = NonNegConstraint()

--- a/src/utilities/conveniencemethods.jl
+++ b/src/utilities/conveniencemethods.jl
@@ -3,7 +3,7 @@
 ##############################################################
 
 import Base.copy
-export copy, GLRM
+export copy, copy_estimate, GLRM
 
 function copy(r::Regularizer)
   newr = typeof(r)()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,19 @@ using Base.Test
 
 # write your own tests here
 @test 1 == 1
+
+
+
+################################################################################
+# ScikitLearnBase test
+using LowRankModels
+import ScikitLearnBase
+
+# Check that KMeans can correctly separate two non-overlapping Gaussians
+srand(21)
+gaussian1 = randn(100, 2) + 5
+gaussian2 = randn(50, 2) - 10
+A = vcat(gaussian1, gaussian2)
+
+model = ScikitLearnBase.fit!(LowRankModels.KMeans(), A)
+@test Set(sum(ScikitLearnBase.transform(model, A), 1)) == Set([100, 50])


### PR DESCRIPTION
`get-params` wasn't working out with the current type definition. I've decided to wrap `GLRM` instead, it's going to be more consistent with the rest of the ScikitLearn.jl algorithms, and allows me to expose more hyperparameters.

I branched from dataframe-ux this time.

PCA works fine, but I'm having issues with K-Means. I've translated [this example](http://scikit-learn.org/stable/auto_examples/cluster/plot_kmeans_digits.html), and instead of getting a nice Voronoi diagram, I get this:

![screen shot 2016-04-28 at 14 05 14](https://cloud.githubusercontent.com/assets/8622776/14896144/4c84a4a0-0d4a-11e6-8e7a-2c0283aea407.png)

Clearly not random, but not quite Voronoi either! To get this picture, I call `transform(kmeans, X)` where X is a two-column matrix containing all (x,y) coordinates. `transform` uses `FixedLatentFeaturesConstraint`. Is there any reason why this would be incompatible with K-Means? Its output doesn't look right, even with abs_tol=1.e-20 (it converges in ~20 iterations)

```
2430x10 Array{Float64,2}:
  0.0       0.0        0.0      …  0.0      0.0      0.0      1.0     
  0.0       0.0        0.0         0.0      0.0      0.0      0.0     
  0.0       0.0        0.0         0.0      0.0      0.0      0.0     
 -0.570026  0.714604  -2.94676     2.10088  2.1646  -1.42798  0.191742
  0.0       0.0        0.0         0.0      0.0      0.0      0.0     
  0.0       0.0        0.0      …  0.0      0.0      0.0      0.0     
  0.0       0.0        0.0         0.0      0.0      0.0      0.0     
  0.0       0.0        0.0         0.0      0.0      0.0      0.0     
  0.0       0.0        0.0         0.0      0.0      0.0      1.0     
  0.0       0.0        0.0         0.0      0.0      0.0      0.0     
...
```

(10 columns because there are 10 digits). Those 10 rows correspond to neighboring pixels. They should all be classified in the same cluster. But even ignoring the anomaly on row 4, the other rows are not consistent at all.

It would be straight-forward to implement `transform` using the distance from each centroid, but if there's something wrong with `transform`, it's better to fix that instead. Any ideas?