### PR TITLE
small performance improvements in quadratic and l1 regularizers

### DIFF
--- a/src/regularizers.jl
+++ b/src/regularizers.jl
@@ -52,7 +52,7 @@ end
 QuadReg() = QuadReg(1)
 prox(r::QuadReg,u::AbstractArray,alpha::Number) = 1/(1+2*alpha*r.scale)*u
 prox!(r::QuadReg,u::Array{Float64},alpha::Number) = scale!(u, 1/(1+2*alpha*r.scale))
-evaluate(r::QuadReg,a::AbstractArray) = r.scale*sum(a.^2)
+evaluate(r::QuadReg,a::AbstractArray) = r.scale*sumabs2(a)
 
 ## constrained QuadLoss regularization
 ## the function r such that
@@ -78,7 +78,7 @@ type OneReg<:Regularizer
 end
 OneReg() = OneReg(1)
 prox(r::OneReg,u::AbstractArray,alpha::Number) = max(u-alpha,0) + min(u+alpha,0)
-evaluate(r::OneReg,a::AbstractArray) = r.scale*sum(abs(a))
+evaluate(r::OneReg,a::AbstractArray) = r.scale*sumabs(a)
 
 ## no regularization
 type ZeroReg<:Regularizer


### PR DESCRIPTION
According to http://docs.julialang.org/en/release-0.5/stdlib/collections/ , sumabs2(itr) is faster than sum(itr.^2) and sumabs(itr) is faster than sum(abs(itr)). Makes sense because sum(abs2(itr)) and sum(abs(itr)) make temporary arrays while sumabs2 and sumabs do not.