### PR TITLE
Some performance gains from low-hanging fruit

### DIFF
--- a/src/evaluate_fit.jl
+++ b/src/evaluate_fit.jl
@@ -47,9 +47,6 @@ function col_objective(glrm::AbstractGLRM, j::Int, y::AbstractArray, X::Array{Fl
     @inbounds XYj = XY[obsex,colind]
     @inbounds Aj = convert(Array, glrm.A[obsex,j])
     err += evaluate(glrm.losses[j], XYj, Aj)
-    #=for i in glrm.observed_examples[j]
-        err += evaluate(glrm.losses[j], XY[i,colind], glrm.A[i,j])
-    end=#
     # add regularization penalty
     if include_regularization
         err += evaluate(glrm.ry[j], y)

--- a/src/evaluate_fit.jl
+++ b/src/evaluate_fit.jl
@@ -1,8 +1,8 @@
 export objective, error_metric, impute
 
 ### OBJECTIVE FUNCTION EVALUATION FOR MPCA
-function objective(glrm::GLRM, X::Array{Float64,2}, Y::Array{Float64,2}, 
-                   XY::Array{Float64,2}; 
+function objective(glrm::GLRM, X::Array{Float64,2}, Y::Array{Float64,2},
+                   XY::Array{Float64,2};
                    yidxs = get_yidxs(glrm.losses), # mapping from columns of A to columns of Y; by default, the identity
                    include_regularization=true)
     m,n = size(glrm.A)
@@ -43,9 +43,13 @@ function col_objective(glrm::AbstractGLRM, j::Int, y::AbstractArray, X::Array{Fl
     if length(sz) == 1 colind = 1 else colind = 1:sz[2] end
     err = 0.0
     XY = X'*y
-    for i in glrm.observed_examples[j]
+    obsex = glrm.observed_examples[j]
+    @inbounds XYj = XY[obsex,colind]
+    @inbounds Aj = convert(Array, glrm.A[obsex,j])
+    err += evaluate(glrm.losses[j], XYj, Aj)
+    #=for i in glrm.observed_examples[j]
         err += evaluate(glrm.losses[j], XY[i,colind], glrm.A[i,j])
-    end
+    end=#
     # add regularization penalty
     if include_regularization
         err += evaluate(glrm.ry[j], y)
@@ -54,11 +58,11 @@ function col_objective(glrm::AbstractGLRM, j::Int, y::AbstractArray, X::Array{Fl
 end
 # The user can also pass in X and Y and `objective` will compute XY for them
 function objective(glrm::GLRM, X::Array{Float64,2}, Y::Array{Float64,2};
-                   sparse=false, include_regularization=true, 
+                   sparse=false, include_regularization=true,
                    yidxs = get_yidxs(glrm.losses), kwargs...)
     @assert(size(Y)==(glrm.k,yidxs[end][end]))
     @assert(size(X)==(glrm.k,size(glrm.A,1)))
-    XY = Array(Float64, (size(X,2), size(Y,2))) 
+    XY = Array(Float64, (size(X,2), size(Y,2)))
     if sparse
         # Calculate X'*Y only at observed entries of A
         m,n = size(glrm.A)
@@ -133,7 +137,7 @@ function std_error_metric(glrm::AbstractGLRM, XY::Array{Float64,2}, domains::Arr
     end
     return err
 end
-function error_metric(glrm::AbstractGLRM, XY::Array{Float64,2}, domains::Array{Domain,1}; 
+function error_metric(glrm::AbstractGLRM, XY::Array{Float64,2}, domains::Array{Domain,1};
     standardize=false,
     yidxs = get_yidxs(glrm.losses))
     m,n = size(glrm.A)
@@ -146,8 +150,8 @@ function error_metric(glrm::AbstractGLRM, XY::Array{Float64,2}, domains::Array{D
 end
 # The user can also pass in X and Y and `error_metric` will compute XY for them
 function error_metric(glrm::AbstractGLRM, X::Array{Float64,2}, Y::Array{Float64,2}, domains::Array{Domain,1}=Domain[l.domain for l in glrm.losses]; kwargs...)
-    XY = Array(Float64, (size(X,2), size(Y,2))) 
-    gemm!('T','N',1.0,X,Y,0.0,XY) 
+    XY = Array(Float64, (size(X,2), size(Y,2)))
+    gemm!('T','N',1.0,X,Y,0.0,XY)
     error_metric(glrm, XY, domains; kwargs...)
 end
 # Or just the GLRM and `error_metric` will use glrm.X and .Y

--- a/src/losses.jl
+++ b/src/losses.jl
@@ -38,7 +38,7 @@
 import Base: scale!, *, convert
 import Optim.optimize
 export Loss,
-       DiffLoss, # a category of Losses
+       DiffLoss, ClassificationLoss, SingleDimLoss, # categories of Losses
        QuadLoss, L1Loss, HuberLoss, QuantileLoss, # losses for predicting reals
        PoissonLoss, # losses for predicting integers
        HingeLoss, WeightedHingeLoss, LogisticLoss, # losses for predicting booleans
@@ -55,6 +55,8 @@ abstract Loss
 abstract DiffLoss<:Loss
 # a ClassificationLoss is one in which observed values are true = 1 or false = 0 = -1 AND argmin_a L(u,a) = u>=0 ? true : false
 abstract ClassificationLoss<:Loss
+# Single Dimensional losses are DiffLosses or ClassificationLosses, which allow optimized evaluate and grad functions
+typealias SingleDimLoss Union{DiffLoss, ClassificationLoss}
 
 scale!(l::Loss, newscale::Number) = (l.scale = newscale; l)
 scale(l::Loss) = l.scale
@@ -619,7 +621,7 @@ end
 ## we'll compute it via a stochastic gradient method
 ## with fixed step size
 ## (we don't need a hyper accurate estimate for this)
-function M_estimator(l::MultinomialOrdinalLoss, a::AbstractArray)
+function M_estimator(l::MultinomialOrdinalLoss, a::AbstractVector)
     u = zeros(l.max-1)'
     for i = 1:length(a)
         ai = a[i]
@@ -629,8 +631,7 @@ function M_estimator(l::MultinomialOrdinalLoss, a::AbstractArray)
 end
 
 ### convenience methods for evaluating and computing gradients on vectorized arguments
-
-function evaluate(l::Loss, u::Array{Float64,1}, a::AbstractArray)
+function evaluate(l::Loss, u::Array{Float64,1}, a::AbstractVector)
   @assert size(u) == size(a)
   out = 0
   for i=1:length(a)
@@ -638,8 +639,17 @@ function evaluate(l::Loss, u::Array{Float64,1}, a::AbstractArray)
   end
   return out
 end
+
+#Optimized vector evaluate on single-dimensional losses
+function evaluate(l::SingleDimLoss, u::Vector{Float64}, a::AbstractVector)
+  losseval = (x::Float64, y::Number) -> evaluate(l, x, y)
+  mapped = zeros(u)
+  map!(losseval, mapped, u, a)
+  reduce(+, mapped)
+end
+
 # now for multidimensional losses
-function evaluate(l::Loss, u::Array{Float64,2}, a::AbstractArray)
+function evaluate(l::Loss, u::Array{Float64,2}, a::AbstractVector)
   # @show size(u,1)
   # @show size(a)
   @assert size(u,1) == length(a)
@@ -650,7 +660,7 @@ function evaluate(l::Loss, u::Array{Float64,2}, a::AbstractArray)
   return out
 end
 
-function grad(l::Loss, u::Array{Float64,1}, a::AbstractArray)
+function grad(l::Loss, u::Array{Float64,1}, a::AbstractVector)
   @assert size(u) == size(a)
   mygrad = zeros(size(u))
   for i=1:length(a)
@@ -658,8 +668,16 @@ function grad(l::Loss, u::Array{Float64,1}, a::AbstractArray)
   end
   return mygrad
 end
+
+# Optimized vector grad on single-dimensional losses
+function grad(l::SingleDimLoss, u::Vector{Float64}, a::AbstractVector)
+  lossgrad = (x::Float64,y::Number) -> grad(l, x, y)
+  mapped = zeros(u)
+  map!(lossgrad, mapped, u, a)
+end
+
 # now for multidimensional losses
-function grad(l::Loss, u::Array{Float64,2}, a::AbstractArray)
+function grad(l::Loss, u::Array{Float64,2}, a::AbstractVector)
   @assert size(u,1) == length(a)
   mygrad = zeros(size(u))
   for i=1:length(a)


### PR DESCRIPTION
Changed the col_objective calculation and made the vectorized evaluate and grad methods faster, but I can't think of similar optimizations for row_objective, so the loss function speedup is over half the iterations.