### PR TITLE
Fix Travis testing. Don't use "release" and test on 0.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,13 @@ os:
   - osx
   - linux
 julia:
-  - release
-  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false
+matrix:
+  allow_failures:
+    - julia: nightly
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("LowRankModels"); Pkg.test("LowRankModels"; coverage=true)';


### PR DESCRIPTION
For now, allow that tests on nightly fail.