### PR TITLE
fix Symbol typo

### DIFF
--- a/src/fit_dataframe.jl
+++ b/src/fit_dataframe.jl
@@ -247,7 +247,7 @@ function expand_categoricals!(df::DataFrame,categoricals::Array{Int,1})
         levels = sort(unique(df[:,col]))
         for level in levels
             if !ismissing(level)
-                colname = symbol(string(colnames[col])*"="*string(level))
+                colname = Symbol(string(colnames[col])*"="*string(level))
                 df[colname] = (df[:,col] .== level)
             end
         end


### PR DESCRIPTION
In response to #84. 

The function call `expand_categoricals!(df,[2])` works now. 