### PR TITLE
 Declares the Regularizer type to be a supertype of NonNegQuadReg.

### DIFF
--- a/src/regularizers.jl
+++ b/src/regularizers.jl
@@ -139,7 +139,7 @@ mul!(r::NonNegOneReg, newscale::Number) = 1
 
 ## Quadratic regularization restricted to nonnegative domain
 ## (Enforces nonnegativity alongside quadratic regularization)
-mutable struct NonNegQuadReg
+mutable struct NonNegQuadReg<:Regularizer
     scale::Float64
 end
 NonNegQuadReg() = NonNegQuadReg(1)


### PR DESCRIPTION
Previously we couldn't use NonNegQuadReg because it was not declared as a subtype of Regularizer as GLRM methods' signatures require it to be.