### PR TITLE
fix NaNtoMissing

### DIFF
--- a/src/fit_dataframe.jl
+++ b/src/fit_dataframe.jl
@@ -2,7 +2,6 @@
 # REVIEW THIS IN LIGHT OF NEW DATAFRAMES
 # ========================================
 
-import Base: isnan
 import DataFrames: DataFrame, ncol, convert
 
 
@@ -269,16 +268,12 @@ function expand_categoricals!(df::DataFrame,categoricals::Array)
     return expand_categoricals!(df, categoricalidxs)
 end
 
-# convert NaNs to NAs
-# isnan(x::NAtype) = false
-isnan(x::AbstractString) = false
-isnan(x::Union{T, Nothing}) where T = isnan(x.value)
 
 # same functionality as above.
 function NaNs_to_Missing!(df::DataFrame)
     m,n = size(df)
     for j=1:n
-        df[!,j] = [ismissing(df[i,j]) || isnan(df[i,j]) ? missing : value for (i,value) in enumerate(df[:,j])];
+        df[!,j] = [(value isa Number && isnan(value)) ? missing : value for value in df[!,j]];
 	end
     return df
 end


### PR DESCRIPTION
running the tests was erroring with:
```
ERROR: LoadError: LoadError: LoadError: type CategoricalValue has no field value
Stacktrace:
  [1] getproperty(x::CategoricalValue{String, UInt8}, f::Symbol)
    @ Base ./Base.jl:33
  [2] isnan(x::CategoricalValue{String, UInt8})
    @ LowRankModels ~/JuliaEnvs/LowRankModels.jl/src/fit_dataframe.jl:275
  [3] (::LowRankModels.var"#147#148"{DataFrame, Int64})(::Tuple{Int64, CategoricalValue{String, UInt8}})
    @ LowRankModels ./none:0
  [4] iterate
    @ ./generator.jl:47 [inlined]
  [5] collect(itr::Base.Generator{Base.Iterators.Enumerate{CategoricalVector{String, UInt8, String, Cate
goricalValue{String, UInt8}, Union{}}}, LowRankModels.var"#147#148"{DataFrame, Int64}})
    @ Base ./array.jl:678
  [6] NaNs_to_Missing!(df::DataFrame)
    @ LowRankModels ~/JuliaEnvs/LowRankModels.jl/src/fit_dataframe.jl:281
  [7] GLRM(df::DataFrame, k::Int64; losses::Vector{Loss}, rx::QuadReg, ry::QuadReg, offset::Bool, scale:
:Bool, prob_scale::Bool, NaNs_to_Missing::Bool)
    @ LowRankModels ~/JuliaEnvs/LowRankModels.jl/src/fit_dataframe_w_type_imputation.jl:17
  [8] GLRM(df::DataFrame, k::Int64)
    @ LowRankModels ~/JuliaEnvs/LowRankModels.jl/src/fit_dataframe_w_type_imputation.jl:15
  [9] top-level scope
    @ ~/JuliaEnvs/LowRankModels.jl/examples/fit_rdataset.jl:9
 [10] include(fname::String)
    @ Base.MainInclude ./client.jl:444
 [11] top-level scope
    @ ~/JuliaEnvs/LowRankModels.jl/examples/runexamples.jl:17
 [12] include(fname::String)
    @ Base.MainInclude ./client.jl:444
 [13] top-level scope
    @ ~/JuliaEnvs/LowRankModels.jl/test/runtests.jl:34
 [14] include(fname::String)
    @ Base.MainInclude ./client.jl:444
 [15] top-level scope
    @ none:6
in expression starting at /Users/oxinabox/JuliaEnvs/LowRankModels.jl/examples/fit_rdataset.jl:9
in expression starting at /Users/oxinabox/JuliaEnvs/LowRankModels.jl/examples/runexamples.jl:17
in expression starting at /Users/oxinabox/JuliaEnvs/LowRankModels.jl/test/runtests.jl:34
ERROR: Package LowRankModels errored during testing
```

Looking at the code for `NaNtoMissing` it was a bit funky.
I made it less funky.

Now tests pass without errors for me